### PR TITLE
Polish hero header and refactor trusted brands section

### DIFF
--- a/index.html
+++ b/index.html
@@ -361,13 +361,12 @@
         }
 
         .icons-grid {
-            display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-            gap: 2rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 1.5rem;
             max-width: 1000px;
             margin: 0 auto;
-            align-items: stretch;
-            grid-auto-rows: 1fr;
+            justify-content: center;
         }
 
         .brand-card {
@@ -376,12 +375,13 @@
             align-items: center;
             justify-content: center;
             gap: 1rem;
-            padding: 2rem 1rem;
-            background: rgba(255, 255, 255, 0.06);
+            width: 140px;
+            height: 160px;
+            padding: 1.5rem 1rem;
+            background: rgba(255, 255, 255, 0.08);
             border: 1px solid rgba(255, 255, 255, 0.2);
             border-radius: 16px;
             transition: background 0.3s ease, transform 0.3s ease, box-shadow 0.3s ease;
-            height: 100%;
         }
 
         .brand-card:hover,
@@ -560,9 +560,9 @@
         .metric-item {
             text-align: center;
             padding: 1.5rem;
-            background: rgba(255, 255, 255, 0.05);
+            background: rgba(255, 255, 255, 0.08);
             border-radius: 12px;
-            border: 1px solid var(--glass-border);
+            border: 1px solid rgba(255, 255, 255, 0.2);
             backdrop-filter: blur(20px);
             transition: all 0.3s ease;
         }
@@ -847,6 +847,10 @@
 
         /* Responsive Design */
         @media (max-width: 768px) {
+            body {
+                --text-secondary: rgba(255, 255, 255, 0.9);
+                --text-muted: rgba(255, 255, 255, 0.7);
+            }
             .mobile-toggle {
                 display: flex;
             }
@@ -890,14 +894,26 @@
                 padding-bottom: 3rem;
             }
 
+            .hero h1 {
+                font-size: 2.8rem;
+                margin-bottom: 1.5rem;
+            }
+
+            .hero p {
+                margin-bottom: 2rem;
+            }
+
+            .hero-cta {
+                margin-top: 2rem;
+            }
+
             .cta-button {
                 width: 100%;
-                max-width: 300px;
+                display: block;
             }
 
             .icons-grid {
-                grid-template-columns: repeat(3, 1fr);
-                gap: 1.5rem;
+                justify-content: center;
             }
 
             .solutions-grid {
@@ -919,14 +935,27 @@
                 gap: 1rem;
             }
 
+            .metric-item {
+                padding: 1.25rem;
+            }
+
             .footer-content {
                 grid-template-columns: 1fr;
                 gap: 2rem;
                 text-align: center;
             }
 
-            .logo-text {
+            .logo-subtitle {
                 display: none;
+            }
+
+            .logo-title {
+                font-size: 1.25rem;
+            }
+
+            .logo-text {
+                flex-direction: row;
+                align-items: center;
             }
 
             .testimonial-preview {
@@ -935,8 +964,12 @@
         }
 
         @media (max-width: 480px) {
-            .icons-grid {
-                grid-template-columns: repeat(2, 1fr);
+            .hero h1 {
+                font-size: 2.5rem;
+            }
+
+            .hero p {
+                font-size: 1.1rem;
             }
 
             .solution-card {
@@ -1080,27 +1113,7 @@
                 <span>Lounges</span>
             </div>
             
-            <div class="brand-card" tabindex="0" aria-label="Hookah or Hybrid venues">
-                <svg viewBox="0 0 64 64" aria-hidden="true">
-                    <rect x="28" y="8" width="8" height="40" rx="4"/>
-                    <circle cx="32" cy="52" r="6"/>
-                    <path d="M26 20Q32 16 38 20"/>
-                    <path d="M26 28Q32 24 38 28"/>
-                    <path d="M26 36Q32 32 38 36"/>
-                </svg>
-                <span>Hookah/Hybrid</span>
-            </div>
             
-            <div class="brand-card" tabindex="0" aria-label="Analytics and Franchise operations">
-                <svg viewBox="0 0 64 64" aria-hidden="true">
-                    <rect x="8" y="16" width="48" height="32" rx="4"/>
-                    <path d="M16 28L24 36L48 20"/>
-                    <circle cx="20" cy="32" r="2"/>
-                    <circle cx="32" cy="24" r="2"/>
-                    <circle cx="44" cy="36" r="2"/>
-                </svg>
-                <span>Analytics/Franchise</span>
-            </div>
         </div>
     </section>
 

--- a/index.html
+++ b/index.html
@@ -47,13 +47,13 @@
             width: 100%;
             z-index: 1000;
             backdrop-filter: blur(20px);
-            background: rgba(10, 26, 47, 0.9);
-            border-bottom: 1px solid var(--glass-border);
+            background: linear-gradient(135deg, rgba(0, 0, 0, 0.65), rgba(30, 30, 30, 0.65));
+            border-bottom: 1px solid rgba(255, 255, 255, 0.1);
             transition: all 0.3s ease;
         }
 
         .header.scrolled {
-            background: rgba(10, 26, 47, 0.95);
+            background: linear-gradient(135deg, rgba(0, 0, 0, 0.85), rgba(20, 20, 20, 0.85));
             box-shadow: 0 8px 40px rgba(0, 0, 0, 0.3);
         }
 
@@ -239,9 +239,7 @@
             line-height: 1.1;
             margin-bottom: 2rem;
             letter-spacing: -0.04em;
-            background: linear-gradient(135deg, var(--white) 0%, var(--accent-start) 50%, var(--accent-end) 100%);
-            -webkit-background-clip: text;
-            -webkit-text-fill-color: transparent;
+            color: var(--white);
             animation: fadeInUp 1s ease-out;
         }
 
@@ -353,58 +351,68 @@
         }
 
         .industry-icons h3 {
-            font-size: 1rem;
-            color: var(--text-muted);
+            font-size: 1.25rem;
+            color: var(--white);
             margin-bottom: 4rem;
             text-transform: uppercase;
             letter-spacing: 0.15em;
-            font-weight: 600;
+            font-weight: 700;
+            text-align: center;
         }
 
         .icons-grid {
             display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
-            gap: 3rem;
+            grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+            gap: 2rem;
             max-width: 1000px;
             margin: 0 auto;
-            align-items: center;
+            align-items: stretch;
+            grid-auto-rows: 1fr;
         }
 
-        .industry-icon {
+        .brand-card {
             display: flex;
             flex-direction: column;
             align-items: center;
+            justify-content: center;
             gap: 1rem;
             padding: 2rem 1rem;
-            background: rgba(255, 255, 255, 0.03);
-            border: 1px solid var(--glass-border);
+            background: rgba(255, 255, 255, 0.06);
+            border: 1px solid rgba(255, 255, 255, 0.2);
             border-radius: 16px;
-            transition: all 0.4s ease;
-            opacity: 0.7;
+            transition: background 0.3s ease, transform 0.3s ease, box-shadow 0.3s ease;
+            height: 100%;
         }
 
-        .industry-icon:hover {
-            opacity: 1;
-            transform: translateY(-8px);
+        .brand-card:hover,
+        .brand-card:focus-visible {
+            background: rgba(255, 255, 255, 0.1);
+            transform: translateY(-4px);
             box-shadow: var(--glow-blue);
-            border-color: rgba(0, 196, 204, 0.3);
         }
 
-        .industry-icon svg {
-            width: 64px;
-            height: 64px;
-            fill: var(--text-secondary);
-            transition: all 0.3s ease;
+        .brand-card:focus-visible {
+            outline: 2px solid var(--accent-start);
+            outline-offset: 4px;
         }
 
-        .industry-icon:hover svg {
-            fill: var(--accent-start);
+        .brand-card svg {
+            width: 48px;
+            height: 48px;
+            fill: var(--white);
+            transition: transform 0.3s ease;
         }
 
-        .industry-icon span {
+        .brand-card:hover svg,
+        .brand-card:focus-visible svg {
+            transform: scale(1.05);
+        }
+
+        .brand-card span {
             font-size: 0.9rem;
-            color: var(--text-secondary);
-            font-weight: 500;
+            color: var(--white);
+            font-weight: 600;
+            text-align: center;
         }
 
         /* Solutions Section */
@@ -1022,21 +1030,15 @@
                 Takes 30 seconds. No tech setup required.
             </div>
             
-            <div class="testimonial-preview">
-                <div class="testimonial-quote">"Saved us 9 hours of manual updates every week." — Bar Manager</div>
-                <div class="testimonial-quote">"Rebuilt our menu layout in 10 seconds with MenuIQ™."</div>
-                <div class="testimonial-quote">"Guests are ordering more — we actually track it."</div>
-                <div class="testimonial-author">Real customer feedback</div>
-            </div>
         </div>
     </section>
 
     <!-- Industry Icons Section -->
-    <section class="industry-icons">
-        <h3>Trusted by Leading Hospitality Brands</h3>
+    <section class="industry-icons" aria-labelledby="trusted-brands-heading">
+        <h3 id="trusted-brands-heading">Trusted by Leading Hospitality Brands</h3>
         <div class="icons-grid">
-            <div class="industry-icon">
-                <svg viewBox="0 0 64 64">
+            <div class="brand-card" tabindex="0" aria-label="Restaurants">
+                <svg viewBox="0 0 64 64" aria-hidden="true">
                     <path d="M32 8L36 20H48L39 28L42 40L32 34L22 40L25 28L16 20H28L32 8Z"/>
                     <circle cx="32" cy="48" r="6"/>
                     <rect x="26" y="54" width="12" height="2"/>
@@ -1044,8 +1046,8 @@
                 <span>Restaurants</span>
             </div>
             
-            <div class="industry-icon">
-                <svg viewBox="0 0 64 64">
+            <div class="brand-card" tabindex="0" aria-label="Wine Bars">
+                <svg viewBox="0 0 64 64" aria-hidden="true">
                     <path d="M20 12C20 8 24 4 32 4S44 8 44 12V20C44 24 40 28 32 28S20 24 20 20V12Z"/>
                     <rect x="30" y="28" width="4" height="20"/>
                     <ellipse cx="32" cy="50" rx="8" ry="4"/>
@@ -1054,8 +1056,8 @@
                 <span>Wine Bars</span>
             </div>
             
-            <div class="industry-icon">
-                <svg viewBox="0 0 64 64">
+            <div class="brand-card" tabindex="0" aria-label="Coffee Shops">
+                <svg viewBox="0 0 64 64" aria-hidden="true">
                     <rect x="24" y="20" width="16" height="32" rx="2"/>
                     <rect x="28" y="12" width="8" height="8" rx="4"/>
                     <circle cx="28" cy="30" r="2"/>
@@ -1065,8 +1067,8 @@
                 <span>Coffee Shops</span>
             </div>
             
-            <div class="industry-icon">
-                <svg viewBox="0 0 64 64">
+            <div class="brand-card" tabindex="0" aria-label="Lounges">
+                <svg viewBox="0 0 64 64" aria-hidden="true">
                     <rect x="12" y="24" width="40" height="24" rx="4"/>
                     <rect x="16" y="28" width="8" height="4"/>
                     <rect x="28" y="28" width="8" height="4"/>
@@ -1078,8 +1080,8 @@
                 <span>Lounges</span>
             </div>
             
-            <div class="industry-icon">
-                <svg viewBox="0 0 64 64">
+            <div class="brand-card" tabindex="0" aria-label="Hookah or Hybrid venues">
+                <svg viewBox="0 0 64 64" aria-hidden="true">
                     <rect x="28" y="8" width="8" height="40" rx="4"/>
                     <circle cx="32" cy="52" r="6"/>
                     <path d="M26 20Q32 16 38 20"/>
@@ -1089,8 +1091,8 @@
                 <span>Hookah/Hybrid</span>
             </div>
             
-            <div class="industry-icon">
-                <svg viewBox="0 0 64 64">
+            <div class="brand-card" tabindex="0" aria-label="Analytics and Franchise operations">
+                <svg viewBox="0 0 64 64" aria-hidden="true">
                     <rect x="8" y="16" width="48" height="32" rx="4"/>
                     <path d="M16 28L24 36L48 20"/>
                     <circle cx="20" cy="32" r="2"/>


### PR DESCRIPTION
## Summary
- refine header with dark gradient to better complement site background
- switch hero headline to clean white text
- remove the "Real customer feedback" testimonial box from hero
- refactor trusted brands section into responsive, accessible grid with higher contrast and hover/focus effects

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688ed3e40ae0832781b782fbd6e7abc0